### PR TITLE
Changed the src of the bundle icon in manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,7 @@
   "background_color": "#4996C9",
   "icons": [
     {
-      "src": "bundle-square-icon.png",
+      "src": "bundle-square-icon-180x180.png",
       "sizes": "64x64 32x32 24x24 16x16 144x144",
       "type": "image/png"
     },


### PR DESCRIPTION
There was an error saying the icon could not be found in manifest.json. So updated the icon object source to the correct source found in the public folder.