### PR TITLE
Packing Overview Header Finalize

### DIFF
--- a/src/containers/PackingOverview/PackingOverview.js
+++ b/src/containers/PackingOverview/PackingOverview.js
@@ -248,40 +248,53 @@ export default (class PackingOverview extends Component {
     const {
       alertDisplay,
       lists,
+      todoList,
       currentListDisplay,
       height,
       width
     } = this.state;
     const { completedTodos, incompleteTodos } = this.getListItemsCount();
     const infoBarHeight = Math.floor(height * 0.17);
+    const total = Math.floor((completedTodos / todoList.length) * 100);
     return (
-      <div className="row justify-content-around no-gutters">
-        {lists.length
-          ? lists.map((e, i) => {
-              return (
-                <ListCard
-                  key={i}
-                  {...e}
-                  currentListDisplay={currentListDisplay}
-                  handleCurrentListDisplay={this.handleCurrentListDisplay}
-                  completedTodos={completedTodos}
-                  incompleteTodos={incompleteTodos}
-                  infoBarHeight={infoBarHeight}
-                  width={width}
+      <>
+        <div className="col-2 offset-2 pt-2">
+          <ProgressBar
+            total={total}
+            width={width}
+            infoBarHeight={infoBarHeight}
+          />
+        </div>
+        <div className="col-8 ">
+          <div className="row justify-content-around no-gutters">
+            {lists.length
+              ? lists.map((e, i) => {
+                  return (
+                    <ListCard
+                      key={i}
+                      {...e}
+                      currentListDisplay={currentListDisplay}
+                      handleCurrentListDisplay={this.handleCurrentListDisplay}
+                      completedTodos={completedTodos}
+                      incompleteTodos={incompleteTodos}
+                      infoBarHeight={infoBarHeight}
+                      width={width}
+                    />
+                  );
+                })
+              : null}
+            {lists.length < 2 ? (
+              <div className="col-3">
+                <AddListButton
+                  createList={this.handleCreateList}
+                  handleSelectList={this.handleSelectList}
+                  alertDisplay={alertDisplay}
                 />
-              );
-            })
-          : null}
-        {lists.length < 2 ? (
-          <div className="col-3">
-            <AddListButton
-              createList={this.handleCreateList}
-              handleSelectList={this.handleSelectList}
-              alertDisplay={alertDisplay}
-            />
+              </div>
+            ) : null}
           </div>
-        ) : null}
-      </div>
+        </div>
+      </>
     );
   };
 
@@ -453,39 +466,41 @@ export default (class PackingOverview extends Component {
                 windowHeight={height}
               />
               <div className="row mt-1 no-gutters">
-                <div className="col-2 offset-2 pt-2">
-                  <ProgressBar
-                    total={total}
-                    width={width}
-                    infoBarHeight={infoBarHeight}
-                  />
-                </div>
-                <div className="col-8 ">
-                  {page === "reminders" ? (
-                    this.renderListCards()
-                  ) : (
-                    <div className="row justify-content-around no-gutters">
-                      {bags.map((e, i) => {
-                        return (
-                          <BagSelector
-                            {...e}
-                            bag_type={bagTypes[e.type_id]}
-                            key={i}
-                            countAndKey={this.getItemCountAndKey(
-                              bagTypes[e.type_id],
-                              e.trip_id,
-                              e.bag_id
-                            )}
-                            displayBag={displayBag}
-                            handleOnClick={this.handleOnClick}
-                            width={width}
-                            infoBarHeight={infoBarHeight}
-                          />
-                        );
-                      })}
+                {page === "reminders" ? (
+                  this.renderListCards()
+                ) : (
+                  <>
+                    <div className="col-2 offset-2 pt-2">
+                      <ProgressBar
+                        total={total}
+                        width={width}
+                        infoBarHeight={infoBarHeight}
+                      />
                     </div>
-                  )}
-                </div>
+                    <div className="col-8 ">
+                      <div className="row justify-content-around no-gutters">
+                        {bags.map((e, i) => {
+                          return (
+                            <BagSelector
+                              {...e}
+                              bag_type={bagTypes[e.type_id]}
+                              key={i}
+                              countAndKey={this.getItemCountAndKey(
+                                bagTypes[e.type_id],
+                                e.trip_id,
+                                e.bag_id
+                              )}
+                              displayBag={displayBag}
+                              handleOnClick={this.handleOnClick}
+                              width={width}
+                              infoBarHeight={infoBarHeight}
+                            />
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
             {page === "packing" ? (

--- a/src/containers/PackingOverview/PackingOverview.js
+++ b/src/containers/PackingOverview/PackingOverview.js
@@ -23,7 +23,8 @@ import {
   newQuantity,
   quantity,
   select,
-  unpack
+  unpack,
+  getTripImg
 } from "../../services/packingPage";
 import {
   fetchLists,
@@ -42,6 +43,7 @@ export default (class PackingOverview extends Component {
       page: "packing",
       bagTypes: { 1: "Personal", 2: "Carry-On", 3: "Checked" },
       bagName: "Personal",
+      destinationImage: null,
       currentBag: null,
       currentCategory: null,
       bags: null,
@@ -84,13 +86,19 @@ export default (class PackingOverview extends Component {
         tripBagsAndLists,
         allCategories
       ]);
+      const destinationImage = await getTripImg(
+        tripDetails.trip.id,
+        tripDetails.trip.name,
+        tripDetails.trip.city
+      );
       this.setState(
         {
           tripInfo: tripDetails.trip,
           categories,
           bags: tripDetails.bags,
           lists: tripDetails.lists,
-          loading: false
+          loading: false,
+          destinationImage
         },
         async () => {
           const { bags, lists, bagTypes } = this.state;
@@ -446,9 +454,9 @@ export default (class PackingOverview extends Component {
       shoppingList,
       shoppingListId,
       alertDisplay,
-      currentListDisplay
+      currentListDisplay,
+      destinationImage
     } = this.state;
-    const city = tripInfo ? tripInfo.city.replace(/\s/g, "%20") : "";
     const bagContents = displayBag ? this.state[displayBag] : [];
     const total = Math.floor((totalPacked / totalItems) * 100);
     const infoBarHeight = Math.floor(height * 0.17);
@@ -466,8 +474,8 @@ export default (class PackingOverview extends Component {
             >
               <img
                 className="packing--img-cover"
-                src={`https://source.unsplash.com/weekly?${city}`}
-                alt={`cover of ${city}`}
+                src={destinationImage}
+                alt={`cover of ${tripInfo.city}`}
               />
               <Tabs
                 page={page}

--- a/src/containers/PackingOverview/PackingOverview.js
+++ b/src/containers/PackingOverview/PackingOverview.js
@@ -209,14 +209,12 @@ export default (class PackingOverview extends Component {
 
   handleAddTodo = async todoInput => {
     const newState = await addTodo(todoInput, this.state);
-    console.log(newState, "new");
     if (newState) this.setState(newState);
     return;
   };
 
   handleCompleteTodo = async (index, todo_id) => {
     const newState = await completeTodo(index, todo_id, this.state);
-    console.log(newState, "new");
     if (newState) this.setState(newState);
     return;
   };
@@ -233,7 +231,15 @@ export default (class PackingOverview extends Component {
     if (response) {
       const copiedLists = [...lists];
       copiedLists.push(response);
-      this.setState({ lists: copiedLists });
+      response.list_type === "To Do List"
+        ? this.setState({
+            lists: copiedLists,
+            todoListId: response.todolist_id
+          })
+        : this.setState({
+            lists: copiedLists,
+            shoppingListId: response.todolist_id
+          });
     } else {
       this.setState({ alertDisplay: true });
     }

--- a/src/containers/PackingOverview/PackingOverview.js
+++ b/src/containers/PackingOverview/PackingOverview.js
@@ -255,7 +255,10 @@ export default (class PackingOverview extends Component {
     } = this.state;
     const { completedTodos, incompleteTodos } = this.getListItemsCount();
     const infoBarHeight = Math.floor(height * 0.17);
-    const total = Math.floor((completedTodos / todoList.length) * 100);
+    let total = completedTodos
+      ? Math.floor((completedTodos / todoList.length) * 100)
+      : 0;
+    // total = isNaN(total)? 0 : total;
     return (
       <>
         <div className="col-2 offset-2 pt-2">

--- a/src/containers/PackingOverview/PackingOverview.js
+++ b/src/containers/PackingOverview/PackingOverview.js
@@ -44,6 +44,8 @@ export default (class PackingOverview extends Component {
       bagTypes: { 1: "Personal", 2: "Carry-On", 3: "Checked" },
       bagName: "Personal",
       destinationImage: null,
+      remindersImage:
+        "https://images.unsplash.com/photo-1501618669935-18b6ecb13d6d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2232&q=80",
       currentBag: null,
       currentCategory: null,
       bags: null,
@@ -455,7 +457,8 @@ export default (class PackingOverview extends Component {
       shoppingListId,
       alertDisplay,
       currentListDisplay,
-      destinationImage
+      destinationImage,
+      remindersImage
     } = this.state;
     const bagContents = displayBag ? this.state[displayBag] : [];
     const total = Math.floor((totalPacked / totalItems) * 100);
@@ -474,7 +477,7 @@ export default (class PackingOverview extends Component {
             >
               <img
                 className="packing--img-cover"
-                src={destinationImage}
+                src={page === "packing" ? destinationImage : remindersImage}
                 alt={`cover of ${tripInfo.city}`}
               />
               <Tabs

--- a/src/containers/PackingOverview/PackingOverview.js
+++ b/src/containers/PackingOverview/PackingOverview.js
@@ -258,7 +258,6 @@ export default (class PackingOverview extends Component {
     let total = completedTodos
       ? Math.floor((completedTodos / todoList.length) * 100)
       : 0;
-    // total = isNaN(total)? 0 : total;
     return (
       <>
         <div className="col-2 offset-2 pt-2">

--- a/src/containers/PackingOverview/PackingOverview.js
+++ b/src/containers/PackingOverview/PackingOverview.js
@@ -245,10 +245,17 @@ export default (class PackingOverview extends Component {
   };
 
   renderListCards = () => {
-    const { alertDisplay, lists, currentListDisplay } = this.state;
+    const {
+      alertDisplay,
+      lists,
+      currentListDisplay,
+      height,
+      width
+    } = this.state;
     const { completedTodos, incompleteTodos } = this.getListItemsCount();
+    const infoBarHeight = Math.floor(height * 0.17);
     return (
-      <div className="row">
+      <div className="row justify-content-around no-gutters">
         {lists.length
           ? lists.map((e, i) => {
               return (
@@ -259,6 +266,8 @@ export default (class PackingOverview extends Component {
                   handleCurrentListDisplay={this.handleCurrentListDisplay}
                   completedTodos={completedTodos}
                   incompleteTodos={incompleteTodos}
+                  infoBarHeight={infoBarHeight}
+                  width={width}
                 />
               );
             })

--- a/src/containers/PackingOverview/PackingOverview.js
+++ b/src/containers/PackingOverview/PackingOverview.js
@@ -291,6 +291,8 @@ export default (class PackingOverview extends Component {
                   createList={this.handleCreateList}
                   handleSelectList={this.handleSelectList}
                   alertDisplay={alertDisplay}
+                  infoBarHeight={infoBarHeight}
+                  width={width}
                 />
               </div>
             ) : null}

--- a/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.css
+++ b/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.css
@@ -1,0 +1,94 @@
+.cList--inactive-color {
+  background-color: #d3d3d3;
+}
+
+.cList--active-color {
+  background-color: #4896c9;
+}
+.cList--active {
+  width: 100%;
+  height: 100%;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--bundleBlue);
+  border: solid 1px var(--bundleBlue);
+  border-radius: var(--br-9);
+  box-shadow: var(--ds-lightGrey);
+  background-color: var(--white);
+  transition: 0.3s;
+}
+
+.cList--inactive {
+  width: 100%;
+  height: 100%;
+  font-size: 1.2rem;
+  border: solid 1px var(--smokeGrey30);
+  color: var(--bundleBlue70);
+  border-radius: var(--br-9);
+  box-shadow: var(--smokeGrey30);
+  background-color: rgba(255, 255, 255, 0.938);
+  transition: 0.3s;
+}
+
+.cList--inactive:hover {
+  width: 100%;
+  height: 100%;
+  font-weight: 700;
+  color: var(--bundleBlue);
+  border: solid 1px var(--bundleBlue);
+  border-radius: var(--br-9);
+  box-shadow: var(--ds-lightGrey);
+  background-color: var(--white);
+  transition: 0.3s;
+}
+
+.cList--button {
+  background: none;
+  display: inline-block;
+  border: none;
+  margin: 0;
+  text-decoration: none;
+  cursor: pointer;
+  text-align: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-align: left;
+}
+
+.cList--button:hover,
+.cList--button:focus {
+  font-weight: 700;
+  outline: var(--bundleBlue);
+}
+
+/* sizing */
+
+.cList--size {
+  height: 7rem;
+  width: 6.8rem;
+  font-size: 1rem;
+}
+
+.cList--size-md {
+  height: 7rem;
+  width: 8.2rem;
+  font-size: 1.1rem;
+}
+
+.cList--size-lg {
+  height: 8rem;
+  width: 10rem;
+  font-size: 1.2rem;
+}
+
+.cList--size-xlg {
+  height: 8rem;
+  width: 12rem;
+  font-size: 1.3rem;
+}
+
+.cList--size-xxlg {
+  height: 9rem;
+  width: 13rem;
+  font-size: 1.5rem;
+}

--- a/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.css
+++ b/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.css
@@ -92,3 +92,34 @@
   width: 13rem;
   font-size: 1.5rem;
 }
+
+.addlist--modal-button {
+  display: inline-block;
+  font-weight: 400;
+  color: var(--bundleBlue);
+  text-align: center;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  background-color: transparent;
+  border: 1px solid transparent;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 0.25rem;
+  border-color: #17a2b8 !important;
+  border: 1px solid var(--bundleBlue);
+}
+
+.addlist--modal-button:hover {
+  border: 1px solid var(--denimBlue);
+  background-color: var(--denimBlue);
+  color: var(--white);
+  transition: 0.3s;
+}
+
+.addlist--modal-close {
+  font-size: 2rem;
+  color: var(--denimBlue);
+}

--- a/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.js
+++ b/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.js
@@ -51,19 +51,21 @@ const AddListButton = props => {
           aria-labelledby="exampleModalLabel"
           aria-hidden="true"
         >
-          <div className="modal-dialog" role="document">
+          <div className="modal-dialog modal-dialog-centered" role="document">
             <div className="modal-content">
               <div className="modal-header">
-                <h5 className="modal-title" id="exampleModalLabel">
-                  Type of List
-                </h5>
+                <h4 className="modal-title" id="exampleModalLabel">
+                  Create A List
+                </h4>
                 <button
                   type="button"
                   className="close"
                   data-dismiss="modal"
                   aria-label="Close"
                 >
-                  <span aria-hidden="true">&times;</span>
+                  <span aria-hidden="true" className="addlist--modal-close">
+                    &times;
+                  </span>
                 </button>
               </div>
               <div className="modal-body">
@@ -81,7 +83,7 @@ const AddListButton = props => {
                     <option value="Shopping List">Shopping List</option>
                   </select>
                   <button
-                    className="btn border border-info"
+                    className="addlist--modal-button"
                     data-dismiss="modal"
                     onClick={createList}
                   >

--- a/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.js
+++ b/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.js
@@ -1,13 +1,117 @@
 import React from "react";
+import "./AddListCard.css";
 
 const AddListButton = props => {
-  const { createList, handleSelectList, alertDisplay } = props;
+  const {
+    createList,
+    handleSelectList,
+    alertDisplay,
+    infoBarHeight,
+    width
+  } = props;
+  const height = Math.floor(infoBarHeight / 2);
+  const dynamicSize = name => {
+    if (width < 500) return `cList--${name}`;
+    if (width >= 500 && width < 990) return `cList--${name}-md`;
+    if (width >= 990 && width < 1200) return `cList--${name}-lg`;
+    if (width >= 1200 && width < 1300) return `cList--${name}-xlg`;
+    if (width > 1300) return `cList--${name}-xxlg`;
+  };
 
   const alert = (
     <div className="alert alert-warning" role="alert">
       Whoops! That list already exists!
     </div>
   );
+
+  if (true) {
+    return (
+      <>
+        <div className={"  mx-1"}>
+          <button
+            className={dynamicSize("size") + " cList--button"}
+            type="button"
+            data-toggle="modal"
+            data-target="#exampleModal"
+            style={{ height: height }}
+          >
+            <div className={"cList--inactive p-2 text-left"}>
+              <p className="row">
+                <span className="col-12">+Add</span>
+              </p>
+            </div>
+          </button>
+        </div>
+
+        <div
+          className="modal fade"
+          id="exampleModal"
+          tabIndex="-1"
+          role="dialog"
+          aria-labelledby="exampleModalLabel"
+          aria-hidden="true"
+        >
+          <div className="modal-dialog" role="document">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title" id="exampleModalLabel">
+                  Modal title
+                </h5>
+                <button
+                  type="button"
+                  className="close"
+                  data-dismiss="modal"
+                  aria-label="Close"
+                >
+                  <span aria-hidden="true">&times;</span>
+                </button>
+              </div>
+              <div className="modal-body">
+                {/*     ///////////      /////////////  */}
+
+                <div className="card card-body">
+                  Type of List
+                  <hr />
+                  <div className="input-group mb-3">
+                    <select
+                      onChange={handleSelectList}
+                      className="custom-select"
+                      id="inputGroupSelect01"
+                    >
+                      <option defaultValue>Choose one...</option>
+                      <option value="To Do List">To Do List</option>
+                      <option value="Shopping List">Shopping List</option>
+                    </select>
+                    <button
+                      className="btn border border-info"
+                      data-dismiss="modal"
+                      onClick={createList}
+                    >
+                      Create
+                    </button>
+                  </div>
+                  {alertDisplay ? alert : null}
+                </div>
+                {/*  /////////////         /////////////////// */}
+              </div>
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  data-dismiss="modal"
+                >
+                  Close
+                </button>
+                <button type="button" className="btn btn-primary">
+                  Save changes
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.js
+++ b/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.js
@@ -23,129 +23,71 @@ const AddListButton = props => {
       Whoops! That list already exists!
     </div>
   );
-
-  if (true) {
-    return (
-      <>
-        <div className={"  mx-1"}>
-          <button
-            className={dynamicSize("size") + " cList--button"}
-            type="button"
-            data-toggle="modal"
-            data-target="#exampleModal"
-            style={{ height: height }}
-          >
-            <div className={"cList--inactive p-2 text-left"}>
-              <p className="row">
-                <span className="col-12">+Add</span>
-              </p>
-            </div>
-          </button>
-        </div>
-
-        <div
-          className="modal fade"
-          id="exampleModal"
-          tabIndex="-1"
-          role="dialog"
-          aria-labelledby="exampleModalLabel"
-          aria-hidden="true"
-        >
-          <div className="modal-dialog modal-dialog-centered" role="document">
-            <div className="modal-content">
-              <div className="modal-header">
-                <h4 className="modal-title" id="exampleModalLabel">
-                  Create A List
-                </h4>
-                <button
-                  type="button"
-                  className="close"
-                  data-dismiss="modal"
-                  aria-label="Close"
-                >
-                  <span aria-hidden="true" className="addlist--modal-close">
-                    &times;
-                  </span>
-                </button>
-              </div>
-              <div className="modal-body">
-                {/*     ///////////      /////////////  */}
-
-                {/* <div className="card card-body"> */}
-                <div className="input-group mb-3">
-                  <select
-                    onChange={handleSelectList}
-                    className="custom-select"
-                    id="inputGroupSelect01"
-                  >
-                    <option defaultValue>Choose one...</option>
-                    <option value="To Do List">To Do List</option>
-                    <option value="Shopping List">Shopping List</option>
-                  </select>
-                  <button
-                    className="addlist--modal-button"
-                    data-dismiss="modal"
-                    onClick={createList}
-                  >
-                    Create
-                  </button>
-                </div>
-                {alertDisplay ? alert : null}
-                {/* </div> */}
-                {/*  /////////////         /////////////////// */}
-              </div>
-            </div>
-          </div>
-        </div>
-      </>
-    );
-  }
-
   return (
     <>
-      <div className="m-3 card" style={{ width: "18rem" }}>
-        <div className="card-body">
-          <p>
-            <a
-              className="btn btn-primary"
-              data-toggle="collapse"
-              href="#multiCollapseExample1"
-              role="button"
-              aria-expanded="false"
-              aria-controls="multiCollapseExample1"
-            >
-              +Add
-            </a>
-          </p>
-          <div className="row">
-            <div className="col">
-              <div
-                className="collapse multi-collapse"
-                id="multiCollapseExample1"
+      <div className={"  mx-1"}>
+        <button
+          className={dynamicSize("size") + " cList--button"}
+          type="button"
+          data-toggle="modal"
+          data-target="#exampleModal"
+          style={{ height: height }}
+        >
+          <div className={"cList--inactive p-2 text-left"}>
+            <p className="row">
+              <span className="col-12">+Add</span>
+            </p>
+          </div>
+        </button>
+      </div>
+
+      <div
+        className="modal fade"
+        id="exampleModal"
+        tabIndex="-1"
+        role="dialog"
+        aria-labelledby="exampleModalLabel"
+        aria-hidden="true"
+      >
+        <div className="modal-dialog modal-dialog-centered" role="document">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h4 className="modal-title" id="exampleModalLabel">
+                Create A List
+              </h4>
+              <button
+                type="button"
+                className="close"
+                data-dismiss="modal"
+                aria-label="Close"
               >
-                <div className="card card-body">
-                  Type of List
-                  <hr />
-                  <div className="input-group mb-3">
-                    <select
-                      onChange={handleSelectList}
-                      className="custom-select"
-                      id="inputGroupSelect01"
-                    >
-                      <option defaultValue>Choose one...</option>
-                      <option value="To Do List">To Do List</option>
-                      <option value="Shopping List">Shopping List</option>
-                    </select>
-                    <button
-                      className="btn border border-info"
-                      onClick={createList}
-                    >
-                      Create
-                    </button>
-                  </div>
-                  {alertDisplay ? alert : null}
-                </div>
+                <span aria-hidden="true" className="addlist--modal-close">
+                  &times;
+                </span>
+              </button>
+            </div>
+            <div className="modal-body">
+              {/*     ///////////      /////////////  */}
+              <div className="input-group mb-3">
+                <select
+                  onChange={handleSelectList}
+                  className="custom-select"
+                  id="inputGroupSelect01"
+                >
+                  <option defaultValue>Choose one...</option>
+                  <option value="To Do List">To Do List</option>
+                  <option value="Shopping List">Shopping List</option>
+                </select>
+                <button
+                  className="addlist--modal-button"
+                  data-dismiss="modal"
+                  onClick={createList}
+                >
+                  Create
+                </button>
               </div>
+              {alertDisplay ? alert : null}
+              {/*  /////////////         /////////////////// */}
             </div>
           </div>
         </div>

--- a/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.js
+++ b/src/containers/PackingOverview/RemindersPage/AddListCard/AddListCard.js
@@ -55,7 +55,7 @@ const AddListButton = props => {
             <div className="modal-content">
               <div className="modal-header">
                 <h5 className="modal-title" id="exampleModalLabel">
-                  Modal title
+                  Type of List
                 </h5>
                 <button
                   type="button"
@@ -69,42 +69,28 @@ const AddListButton = props => {
               <div className="modal-body">
                 {/*     ///////////      /////////////  */}
 
-                <div className="card card-body">
-                  Type of List
-                  <hr />
-                  <div className="input-group mb-3">
-                    <select
-                      onChange={handleSelectList}
-                      className="custom-select"
-                      id="inputGroupSelect01"
-                    >
-                      <option defaultValue>Choose one...</option>
-                      <option value="To Do List">To Do List</option>
-                      <option value="Shopping List">Shopping List</option>
-                    </select>
-                    <button
-                      className="btn border border-info"
-                      data-dismiss="modal"
-                      onClick={createList}
-                    >
-                      Create
-                    </button>
-                  </div>
-                  {alertDisplay ? alert : null}
+                {/* <div className="card card-body"> */}
+                <div className="input-group mb-3">
+                  <select
+                    onChange={handleSelectList}
+                    className="custom-select"
+                    id="inputGroupSelect01"
+                  >
+                    <option defaultValue>Choose one...</option>
+                    <option value="To Do List">To Do List</option>
+                    <option value="Shopping List">Shopping List</option>
+                  </select>
+                  <button
+                    className="btn border border-info"
+                    data-dismiss="modal"
+                    onClick={createList}
+                  >
+                    Create
+                  </button>
                 </div>
+                {alertDisplay ? alert : null}
+                {/* </div> */}
                 {/*  /////////////         /////////////////// */}
-              </div>
-              <div className="modal-footer">
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  data-dismiss="modal"
-                >
-                  Close
-                </button>
-                <button type="button" className="btn btn-primary">
-                  Save changes
-                </button>
               </div>
             </div>
           </div>

--- a/src/containers/PackingOverview/RemindersPage/ListCard/ListCard.css
+++ b/src/containers/PackingOverview/RemindersPage/ListCard/ListCard.css
@@ -1,0 +1,94 @@
+.cList--inactive-color {
+  background-color: #d3d3d3;
+}
+
+.cList--active-color {
+  background-color: #4896c9;
+}
+.cList--active {
+  width: 100%;
+  height: 100%;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--bundleBlue);
+  border: solid 1px var(--bundleBlue);
+  border-radius: var(--br-9);
+  box-shadow: var(--ds-lightGrey);
+  background-color: var(--white);
+  transition: 0.3s;
+}
+
+.cList--inactive {
+  width: 100%;
+  height: 100%;
+  font-size: 1.2rem;
+  border: solid 1px var(--smokeGrey30);
+  color: var(--bundleBlue70);
+  border-radius: var(--br-9);
+  box-shadow: var(--smokeGrey30);
+  background-color: rgba(255, 255, 255, 0.938);
+  transition: 0.3s;
+}
+
+.cList--inactive:hover {
+  width: 100%;
+  height: 100%;
+  font-weight: 700;
+  color: var(--bundleBlue);
+  border: solid 1px var(--bundleBlue);
+  border-radius: var(--br-9);
+  box-shadow: var(--ds-lightGrey);
+  background-color: var(--white);
+  transition: 0.3s;
+}
+
+.cList--button {
+  background: none;
+  display: inline-block;
+  border: none;
+  margin: 0;
+  text-decoration: none;
+  cursor: pointer;
+  text-align: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-align: left;
+}
+
+.cList--button:hover,
+.cList--button:focus {
+  font-weight: 700;
+  outline: var(--bundleBlue);
+}
+
+/* sizing */
+
+.cList--size {
+  height: 7rem;
+  width: 6.8rem;
+  font-size: 1rem;
+}
+
+.cList--size-md {
+  height: 7rem;
+  width: 8.2rem;
+  font-size: 1.1rem;
+}
+
+.cList--size-lg {
+  height: 8rem;
+  width: 10rem;
+  font-size: 1.2rem;
+}
+
+.cList--size-xlg {
+  height: 8rem;
+  width: 12rem;
+  font-size: 1.3rem;
+}
+
+.cList--size-xxlg {
+  height: 9rem;
+  width: 13rem;
+  font-size: 1.5rem;
+}

--- a/src/containers/PackingOverview/RemindersPage/ListCard/ListCard.js
+++ b/src/containers/PackingOverview/RemindersPage/ListCard/ListCard.js
@@ -1,4 +1,5 @@
 import React from "react";
+import "./ListCard.css";
 
 const ListCard = props => {
   const {
@@ -6,23 +7,42 @@ const ListCard = props => {
     name,
     handleCurrentListDisplay,
     completedTodos,
-    incompleteTodos
+    incompleteTodos,
+    width,
+    infoBarHeight,
+    currentListDisplay
   } = props;
+  const dynamicSize = name => {
+    if (width < 500) return `cList--${name}`;
+    if (width >= 500 && width < 990) return `cList--${name}-md`;
+    if (width >= 990 && width < 1200) return `cList--${name}-lg`;
+    if (width >= 1200 && width < 1300) return `cList--${name}-xlg`;
+    if (width > 1300) return `cList--${name}-xxlg`;
+  };
+
   const bool = list_type === "To Do List" ? true : false;
   let totalTodos = completedTodos + incompleteTodos;
   let percentage = Math.floor((completedTodos / totalTodos) * 100);
-
+  const height = Math.floor(infoBarHeight / 2);
+  const selected =
+    currentListDisplay && list_type === "To Do List"
+      ? " cList--active "
+      : " cList--inactive ";
   return (
-    <div className="col-4 m-3 card p-0 rounded">
+    <div className={"  mx-1"}>
       <button
-        className="card-body rounded"
+        className={dynamicSize("size") + " cList--button"}
         onClick={() => handleCurrentListDisplay(bool)}
+        style={{ height: height }}
       >
-        <h5 className="card-title">{list_type}</h5>
-        <p className="card-text">
-          <span>{name}</span>
-        </p>
-        <p>{completedTodos ? percentage + "%" : null}</p>
+        <div className={selected + " p-2 text-left"}>
+          <p className="row">
+            <span className="col-12">{list_type}</span>
+            <span className="col-12">
+              {completedTodos ? percentage + "%" : null}
+            </span>
+          </p>
+        </div>
       </button>
     </div>
   );

--- a/src/containers/PackingOverview/RemindersPage/ListCard/ListCard.js
+++ b/src/containers/PackingOverview/RemindersPage/ListCard/ListCard.js
@@ -39,7 +39,7 @@ const ListCard = props => {
           <p className="row">
             <span className="col-12">{list_type}</span>
             <span className="col-12">
-              {completedTodos ? percentage + "%" : null}
+              {completedTodos ? percentage + "%" : 0 + "%"}
             </span>
           </p>
         </div>

--- a/src/services/packingPage.js
+++ b/src/services/packingPage.js
@@ -421,3 +421,16 @@ export const addToShoppingCart = async (index, state, list_id) => {
     return false;
   }
 };
+
+export const getTripImg = async (id, name, city = "city") => {
+  if (localStorage.getItem(`${name}-${id}-img`)) {
+    return JSON.parse(localStorage.getItem(`${name}-${id}-img`));
+  } else {
+    city = city.includes(" ") ? city.replace(/\s/g, "%20") : city;
+    const { url } = await fetch(`https://source.unsplash.com/weekly?${city}`, {
+      method: "get"
+    });
+    localStorage.setItem(`${name}-${id}-img`, JSON.stringify(url));
+    return url;
+  }
+};


### PR DESCRIPTION
Packing Overview Header
---
- Reminder's List Cards match the same styling as the Packing Bags
- Reminders has its own progress bar for tracking progress
- Replaced the dropdown when adding a List to Reminders with a modal
a. Patched a small bug where when creating a List did not update the state with its respective list id
- Header stores an image url from Unsplash to localStorage avoiding making subsequent calls, resulting in faster image loads 📈 
- Ternary used for rendering Lists, Bags, Progress Bar, and Image depending on page selected