### PR TITLE
Pack page CSS re-touch

### DIFF
--- a/src/components/BagSelectorCard/BagSelectorCard.css
+++ b/src/components/BagSelectorCard/BagSelectorCard.css
@@ -73,24 +73,24 @@
 
 .cbag--size-md {
   height: 7rem;
-  width: 8.2rem;
+  width: 9em;
   font-size: 1.1rem;
 }
 
 .cbag--size-lg {
   height: 8rem;
-  width: 10rem;
+  width: 11em;
   font-size: 1.2rem;
 }
 
 .cbag--size-xlg {
   height: 8rem;
-  width: 12rem;
+  width: 13em;
   font-size: 1.3rem;
 }
 
 .cbag--size-xxlg {
   height: 9rem;
-  width: 13rem;
+  width: 15em;
   font-size: 1.5rem;
 }

--- a/src/components/BagSelectorCard/BagSelectorCard.css
+++ b/src/components/BagSelectorCard/BagSelectorCard.css
@@ -5,13 +5,14 @@
 .cbag--active-color {
   background-color: #4896c9;
 }
+
 .cbag--active {
   width: 100%;
   height: 100%;
   font-weight: 700;
-  font-size: 1.2rem;
+  font-size: 1.3em;
   color: var(--bundleBlue);
-  border: solid 1px var(--bundleBlue);
+  border: solid 0.3em var(--bundleBlue);
   border-radius: var(--br-9);
   box-shadow: var(--ds-lightGrey);
   background-color: var(--white);
@@ -21,7 +22,7 @@
 .cbag--inactive {
   width: 100%;
   height: 100%;
-  font-size: 1.2rem;
+  font-size: 1em;
   border: solid 1px var(--smokeGrey30);
   color: var(--bundleBlue70);
   border-radius: var(--br-9);
@@ -33,9 +34,10 @@
 .cbag--inactive:hover {
   width: 100%;
   height: 100%;
+  font-size: 1.2em;
   font-weight: 700;
   color: var(--bundleBlue);
-  border: solid 1px var(--bundleBlue);
+  /* border: solid .5rem v; */
   border-radius: var(--br-9);
   box-shadow: var(--ds-lightGrey);
   background-color: var(--white);

--- a/src/components/PackingTabs/PackingTabs.css
+++ b/src/components/PackingTabs/PackingTabs.css
@@ -4,24 +4,33 @@
 }
 
 .tabs--header {
-  font-size: 2rem;
+  font-size: 2em;
 }
 
 .tabs-active {
   font-weight: 700;
   color: var(--white);
+  border-bottom: 0.2rem solid white;
+  padding-bottom: 0.4rem;
+  transition: 0.3s;
 }
 
 .tabs-inactive {
   color: rgba(251, 251, 251, 0.8);
 }
 
+.tabs-inactive:hover {
+  border-bottom: 0.2rem solid rgb(179, 176, 176);
+  padding-bottom: 0.4rem;
+  transition: 0.3s;
+}
+
 .tabs--trip {
-  font-size: 1.5rem;
+  font-size: 1.5em;
   color: var(--white);
 }
 .tabs--details {
-  font-size: 1.5rem;
+  font-size: 1.5em;
   color: var(--white);
 }
 

--- a/src/components/PackingTabs/PackingTabs.js
+++ b/src/components/PackingTabs/PackingTabs.js
@@ -9,8 +9,8 @@ export default ({ page, handleOnClick, moveToTrip, windowHeight }) => {
   return (
     <div className="container" style={{ height: `${height}px` }}>
       <div className="row align-items-center tabs--main no-gutters">
-        <div className="pl-2 col-8 offset-2 tabs--header">
-          <div className="row">
+        <div className="pl-2 col-7 offset-3 tabs--header">
+          <div className="row no-gutters">
             <button
               type="button"
               aria-pressed={ariaPressed}

--- a/src/components/PackingTabs/PackingTabs.js
+++ b/src/components/PackingTabs/PackingTabs.js
@@ -35,11 +35,13 @@ export default ({ page, handleOnClick, moveToTrip, windowHeight }) => {
           <button
             type="button"
             aria-label="Trip Details Page"
-            className="row tabs--button align-items-top"
+            className="tabs--button"
             onClick={moveToTrip}
           >
-            <span className="col-12 text-left tabs--trip">Trip</span>
-            <span className="col-12 text-left tabs--details">Details</span>
+            <div className="row align-items-top">
+              <span className="col-12 text-left tabs--trip">Trip</span>
+              <span className="col-12 text-left tabs--details">Details</span>
+            </div>
           </button>
         </div>
       </div>

--- a/src/containers/PackingOverview/PackingOverview.js
+++ b/src/containers/PackingOverview/PackingOverview.js
@@ -472,7 +472,7 @@ export default (class PackingOverview extends Component {
     } = this.state;
     const bagContents = displayBag ? this.state[displayBag] : [];
     const total = Math.floor((totalPacked / totalItems) * 100);
-    const infoBarHeight = Math.floor(height * 0.17);
+    const infoBarHeight = Math.floor(height * 0.2);
     return (
       <>
         {loading ? (

--- a/src/containers/PackingOverview/PackingPage/PackingPage.css
+++ b/src/containers/PackingOverview/PackingPage/PackingPage.css
@@ -7,6 +7,5 @@
 }
 
 .ppage--menubar-position {
-  position: absolute;
   bottom: 4.7em;
 }

--- a/src/containers/PackingOverview/PackingPage/PackingPage.js
+++ b/src/containers/PackingOverview/PackingPage/PackingPage.js
@@ -19,7 +19,7 @@ export default props => {
     bagName
   } = props;
   // const containerHeight = Math.floor(height * 0.83);
-  const containerHeight = Math.floor(height * 0.83);
+  const containerHeight = Math.floor(height * 0.8);
   const bagHeight = Math.floor(containerHeight * 0.98);
   // const bagHeight = Math.floor(height * 0.83);
   return (


### PR DESCRIPTION
- Packing header height increased by 3% 
- Header & bag font changed from `rem` to `em` for mobile/desktop scalability. 
- Packing & Reminders tabs have an underline when active
- Wrapped Trip Details in a `div` to maintain styling post build
- Bags appear larger on medium and higher screens
a. Improved bag border contrast 
